### PR TITLE
docs(postman): add postman collection info to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ $ npm run start:debug
 $ npm run start:prod
 ```
 
+## Documentation
+
+There's a [Postman collection](postman_collection.json) in the repo that allows to consume all the endpoints created.
+If there are new additions to the controllers of the API, please add them to this postman collection, so that other devs have an easier life!
+
 ## Contributing Guide
 
 [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Add postman collection information to the README so that new devs have an easier way to consume the API.